### PR TITLE
Support all-database summaries when no database specified

### DIFF
--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -354,12 +354,14 @@ def db_summary(
 ) -> str:
     try:
         db_name = db if db else db_client.default_database
-        logger.info(f"Getting database summary for: {db_name}, limit={limit}, refresh={refresh}")
-        
         if not db_name:
-            logger.error("Database summary called without database name")
-            return "Error: Database name not provided and no default database is set."
-        
+            logger.info("No database provided. Generating summaries for all databases.")
+            summary = db_summary_manager.get_all_database_summaries(limit=limit, refresh=refresh)
+            logger.info("Database summary completed for all databases")
+            return summary
+
+        logger.info(f"Getting database summary for: {db_name}, limit={limit}, refresh={refresh}")
+
         # Use the database summary manager
         summary = db_summary_manager.get_database_summary(db_name, limit=limit, refresh=refresh)
         logger.info(f"Database summary completed for {db_name}")

--- a/tests/test_db_summary_manager.py
+++ b/tests/test_db_summary_manager.py
@@ -1,0 +1,68 @@
+from src.mcp_server_starrocks.db_summary_manager import DatabaseSummaryManager
+from src.mcp_server_starrocks.db_client import ResultSet
+
+
+class DummyDBClient:
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+
+    def execute(self, statement, db=None):
+        self.calls.append((statement, db))
+        assert statement == "SHOW DATABASES"
+        return ResultSet(success=True, column_names=["Database"], rows=self.rows, execution_time=0.0)
+
+
+def test_get_all_database_summaries_runs_for_each_database():
+    class RecordingManager(DatabaseSummaryManager):
+        def __init__(self, db_client):
+            super().__init__(db_client)
+            self.summary_calls = []
+
+        def get_database_summary(self, database: str, limit: int = 10000, refresh: bool = False) -> str:  # type: ignore[override]
+            self.summary_calls.append((database, limit, refresh))
+            return f"summary-{database}"
+
+    db_client = DummyDBClient([["db1"], ["db2"]])
+    manager = RecordingManager(db_client)
+
+    result = manager.get_all_database_summaries(limit=2048, refresh=True)
+
+    assert "summary-db1" in result
+    assert "summary-db2" in result
+    assert manager.summary_calls == [("db1", 2048, True), ("db2", 2048, True)]
+    assert db_client.calls == [("SHOW DATABASES", None)]
+
+
+def test_get_all_database_summaries_handles_show_databases_error():
+    class FailingDBClient:
+        def execute(self, statement, db=None):
+            return ResultSet(success=False, error_message="boom", execution_time=0.0)
+
+    manager = DatabaseSummaryManager(FailingDBClient())
+    result = manager.get_all_database_summaries()
+
+    assert "Error: Failed to retrieve database list" in result
+
+
+def test_get_all_database_summaries_handles_empty_result():
+    manager = DatabaseSummaryManager(DummyDBClient([]))
+    assert manager.get_all_database_summaries() == "No databases found."
+
+
+def test_get_all_database_summaries_handles_summary_exception():
+    class FaultyManager(DatabaseSummaryManager):
+        def __init__(self, db_client):
+            super().__init__(db_client)
+
+        def get_database_summary(self, database: str, limit: int = 10000, refresh: bool = False) -> str:  # type: ignore[override]
+            if database == "db2":
+                raise RuntimeError("boom")
+            return f"summary-{database}"
+
+    db_client = DummyDBClient([["db1"], ["db2"]])
+    manager = FaultyManager(db_client)
+    result = manager.get_all_database_summaries()
+
+    assert "summary-db1" in result
+    assert "Error generating summary for database 'db2': boom" in result


### PR DESCRIPTION
## Summary
- add `DatabaseSummaryManager.get_all_database_summaries` to aggregate per-database summaries when no database is specified
- update the `db_summary` MCP tool to fall back to scanning every database when no default or explicit database is provided
- cover the new aggregation logic with dedicated unit tests for success and error scenarios

## Testing
- pytest tests/test_db_summary_manager.py


------
https://chatgpt.com/codex/tasks/task_b_68d3cc8a32fc8330b876b2fbe72f2614